### PR TITLE
Upgrade nostr-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "framer-motion": "^10.12.11",
     "jotai": "^2.0.3",
     "jotai-devtools": "^0.5.3",
-    "nostr-fetch": "^0.4.4",
+    "nostr-fetch": "^0.11.0",
     "nostr-tools": "^1.7.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/nostr/EventFetcher.ts
+++ b/src/nostr/EventFetcher.ts
@@ -8,7 +8,7 @@ import type { NostrProfileWithMeta } from "../types/NostrProfile";
 import type { RelayList } from "../types/RelayList";
 import { parseNostrProfile } from "./ProfileParser";
 
-const fetcher = new NostrFetcher({ enableDebugLog: true });
+const fetcher = NostrFetcher.init({ minLogLevel: "info" });
 
 const bootstrapRelays = [
   "wss://relay-jp.nostr.wirednet.jp",
@@ -24,9 +24,10 @@ export class EventFetcher {
     pubkey: string,
     relayUrls: string[]
   ): Promise<NostrProfileWithMeta | undefined> {
-    const ev = await fetcher.fetchLastEvent(this.withBootstraps(relayUrls), [
-      { authors: [pubkey], kinds: [eventKind.metadata] },
-    ]);
+    const ev = await fetcher.fetchLastEvent(this.withBootstraps(relayUrls), {
+      authors: [pubkey],
+      kinds: [eventKind.metadata],
+    });
     if (ev === undefined) {
       return undefined;
     }
@@ -41,9 +42,9 @@ export class EventFetcher {
     pubkeys: string[],
     relayUrls: string[]
   ): AsyncIterable<NostrProfileWithMeta> {
-    const evIter = await fetcher.allEventsIterator(
+    const evIter = fetcher.allEventsIterator(
       this.withBootstraps(relayUrls),
-      [{ authors: pubkeys, kinds: [eventKind.metadata] }],
+      { authors: pubkeys, kinds: [eventKind.metadata] },
       {}
     );
 
@@ -62,9 +63,10 @@ export class EventFetcher {
   ): Promise<{ followList: string[]; relayList: RelayList }> {
     const [k3, k10002] = await Promise.all(
       [eventKind.contacts, eventKind.relayList].map(async (kind) =>
-        fetcher.fetchLastEvent(this.withBootstraps(relayUrls), [
-          { authors: [pubkey], kinds: [kind] },
-        ])
+        fetcher.fetchLastEvent(this.withBootstraps(relayUrls), {
+          authors: [pubkey],
+          kinds: [kind],
+        })
       )
     );
 
@@ -87,9 +89,9 @@ export class EventFetcher {
     timeRangeFilter: FetchTimeRangeFilter,
     relayUrls: string[]
   ): AsyncIterable<NostrEvent> {
-    const evIter = await fetcher.allEventsIterator(
+    const evIter = fetcher.allEventsIterator(
       this.withBootstraps(relayUrls),
-      [{ authors: pubkeys, kinds: [eventKind.text] }],
+      { authors: pubkeys, kinds: [eventKind.text] },
       timeRangeFilter
     );
     for await (const ev of evIter) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,6 +1461,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@nostr-fetch/kernel@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@nostr-fetch/kernel/-/kernel-0.11.0.tgz#c9ca0c947962c6701dc5488da59cabde97f78c19"
+  integrity sha512-OQGAfrGckWkUmFBbE85hq/njVmFrWP21uO8XgXQ1ISS7yrD2N5zcOs1XXXRnaTwIMCv25E8s5Gsgf0AhVWtDEw==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    "@noble/secp256k1" "^1.7.1"
+
 "@popperjs/core@^2.9.3":
   version "2.11.7"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
@@ -3415,13 +3423,12 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-nostr-fetch@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/nostr-fetch/-/nostr-fetch-0.4.4.tgz#1f470781ec05f05a22bb4f0b85e3ade298cbe5ad"
-  integrity sha512-NFrkJuKB82UTirq/0V+ritkkRdFl1wTPPM3wwuTqaf+nzsX1/N26o+aTS59aaRGgsHsxxP9DLeQ7MszGe0eaEg==
+nostr-fetch@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/nostr-fetch/-/nostr-fetch-0.11.0.tgz#731614fa602ad163eff32ed973ee19dd902ba395"
+  integrity sha512-l4GNnS7y4Zc58ROF43uiMPvPVVB8x/hAFqzJpEEqO0IQFQNZ90t6jQIzqPQfy8tFdaPN/n89uaY7KZbNQ7HJsQ==
   dependencies:
-    "@noble/hashes" "^1.2.0"
-    "@noble/secp256k1" "^1.7.1"
+    "@nostr-fetch/kernel" "^0.11.0"
 
 nostr-tools@^1.7.5:
   version "1.8.3"


### PR DESCRIPTION
Upgraded `nostr-fetch` to the latest version.

Also changed logic for getting relay list. It now treat kind:3 and kind:10002 equally (doesn't  prioritize kind:10002).